### PR TITLE
Remove debug log in hotpath.

### DIFF
--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -176,8 +176,8 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 
 	var matchedValues []types.MatchData
 	// we log if we are the parent rule
-	tx.WAF.Logger.Debug("[%s] [%d] Evaluating rule %d", tx.id, rid, r.ID_)
-	defer tx.WAF.Logger.Debug("[%s] [%d] Finish evaluating rule %d", tx.id, rid, r.ID_)
+	//tx.WAF.Logger.Debug("[%s] [%d] Evaluating rule %d", tx.id, rid, r.ID_)
+	//defer tx.WAF.Logger.Debug("[%s] [%d] Finish evaluating rule %d", tx.id, rid, r.ID_)
 	ruleCol := tx.variables.rule
 	ruleCol.SetIndex("id", 0, strconv.Itoa(rid))
 	if r.Msg != nil {
@@ -190,7 +190,7 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 	ruleCol.SetIndex("severity", 0, r.Severity_.String())
 	// SecMark and SecAction uses nil operator
 	if r.operator == nil {
-		tx.WAF.Logger.Debug("[%s] [%d] Forcing rule %d to match", tx.id, rid, r.ID_)
+		//tx.WAF.Logger.Debug("[%s] [%d] Forcing rule %d to match", tx.id, rid, r.ID_)
 		md := &corazarules.MatchData{}
 		matchedValues = append(matchedValues, md)
 		r.matchVariable(tx, md)
@@ -216,14 +216,14 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 			}
 
 			values = tx.GetField(v)
-			tx.WAF.Logger.Debug("[%s] [%d] Expanding %d arguments for rule %d", tx.id, rid, len(values), r.ID_)
+			//tx.WAF.Logger.Debug("[%s] [%d] Expanding %d arguments for rule %d", tx.id, rid, len(values), r.ID_)
 			for i, arg := range values {
-				tx.WAF.Logger.Debug("[%s] [%d] Transforming argument %q for rule %d", tx.id, rid, arg.Value(), r.ID_)
+				//tx.WAF.Logger.Debug("[%s] [%d] Transforming argument %q for rule %d", tx.id, rid, arg.Value(), r.ID_)
 				args, errs := r.transformArg(arg, i, cache)
 				if len(errs) > 0 {
 					tx.WAF.Logger.Debug("[%s] [%d] Error transforming argument %q for rule %d: %v", tx.id, rid, arg.Value(), r.ID_, errs)
 				}
-				tx.WAF.Logger.Debug("[%s] [%d] Arguments transformed for rule %d: %v", tx.id, rid, r.ID_, args)
+				//tx.WAF.Logger.Debug("[%s] [%d] Arguments transformed for rule %d: %v", tx.id, rid, r.ID_, args)
 
 				// args represents the transformed variables
 				for _, carg := range args {
@@ -246,21 +246,21 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 						}
 						matchedValues = append(matchedValues, mr)
 
-						tx.WAF.Logger.Debug("[%s] [%d] Evaluating operator \"%s %s\" against %q: MATCH",
+						/*tx.WAF.Logger.Debug("[%s] [%d] Evaluating operator \"%s %s\" against %q: MATCH",
 							tx.id,
 							rid,
 							r.operator.Function,
 							r.operator.Data,
 							carg,
-						)
+						)*/
 					} else {
-						tx.WAF.Logger.Debug("[%s] [%d] Evaluating operator \"%s %s\" against %q: NO MATCH",
+						/*tx.WAF.Logger.Debug("[%s] [%d] Evaluating operator \"%s %s\" against %q: NO MATCH",
 							tx.id,
 							rid,
 							r.operator.Function,
 							r.operator.Data,
 							carg,
-						)
+						)*/
 					}
 				}
 			}
@@ -275,7 +275,7 @@ func (r *Rule) doEvaluate(phase types.RulePhase, tx *Transaction, cache map[tran
 	if r.ParentID_ == 0 {
 		// we only run the chains for the parent rule
 		for nr := r.Chain; nr != nil; {
-			tx.WAF.Logger.Debug("[%s] [%d] Evaluating rule chain for %d", tx.id, rid, r.ID_)
+			//tx.WAF.Logger.Debug("[%s] [%d] Evaluating rule chain for %d", tx.id, rid, r.ID_)
 			matchedChainValues := nr.doEvaluate(phase, tx, cache)
 			if len(matchedChainValues) == 0 {
 				return matchedChainValues
@@ -347,7 +347,7 @@ func (r *Rule) matchVariable(tx *Transaction, m *corazarules.MatchData) {
 		rid = r.ParentID_
 	}
 	if !m.IsNil() {
-		tx.WAF.Logger.Debug("[%s] [%d] Matching rule %d %s:%s", tx.id, rid, r.ID_, m.VariableName(), m.Key())
+		//tx.WAF.Logger.Debug("[%s] [%d] Matching rule %d %s:%s", tx.id, rid, r.ID_, m.VariableName(), m.Key())
 	}
 	// we must match the vars before running the chains
 
@@ -355,7 +355,7 @@ func (r *Rule) matchVariable(tx *Transaction, m *corazarules.MatchData) {
 	tx.matchVariable(m)
 	for _, a := range r.actions {
 		if a.Function.Type() == rules.ActionTypeNondisruptive {
-			tx.WAF.Logger.Debug("[%s] [%d] Evaluating action %s for rule %d", tx.id, rid, a.Name, r.ID_)
+			//tx.WAF.Logger.Debug("[%s] [%d] Evaluating action %s for rule %d", tx.id, rid, a.Name, r.ID_)
 			a.Function.Evaluate(r, tx)
 		}
 	}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -455,7 +455,7 @@ func (tx *Transaction) matchVariable(match *corazarules.MatchData) {
 
 // MatchRule Matches a rule to be logged
 func (tx *Transaction) MatchRule(r *Rule, mds []types.MatchData) {
-	tx.WAF.Logger.Debug("[%s] rule %d matched", tx.id, r.ID_)
+	//tx.WAF.Logger.Debug("[%s] rule %d matched", tx.id, r.ID_)
 	// tx.MatchedRules = append(tx.MatchedRules, mr)
 
 	// If the rule is set to audit, we log the transaction to the audit log

--- a/internal/seclang/parser.go
+++ b/internal/seclang/parser.go
@@ -141,7 +141,7 @@ func (p *Parser) evaluateLine(data string) error {
 	// first we get the directive
 	dir, opts, _ := strings.Cut(data, " ")
 
-	p.options.WAF.Logger.Debug("parsing directive %q", data)
+	//p.options.WAF.Logger.Debug("parsing directive %q", data)
 	directive := strings.ToLower(dir)
 
 	if len(opts) >= 3 && opts[0] == '"' && opts[len(opts)-1] == '"' {


### PR DESCRIPTION
Debug statements results in lot of memory allocation even if debug log level is not used. This is because logging uses variadic arguments of type interface{} causing variables to escape from the stack to the heap. This also results in increased CPU usage during garbage collection. Commenting these log statements shows 10% improvement in performance during benchmark test of coreruleset (testing/coreruleset).

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: