### PR TITLE
Use string builder in parseActions() to optmize memory usage.

### DIFF
--- a/internal/seclang/rule_parser.go
+++ b/internal/seclang/rule_parser.go
@@ -402,8 +402,11 @@ func getLastRuleExpectingChain(w *corazawaf.WAF) *corazawaf.Rule {
 // Action arguments are allowed to wrap values between colons(”)
 func parseActions(actions string) ([]ruleAction, error) {
 	iskey := true
-	ckey := ""
-	cval := ""
+	var ckey strings.Builder
+	var cval strings.Builder
+	ckey.Reset()
+	cval.Reset()
+
 	quoted := false
 	var res []ruleAction
 actionLoop:
@@ -413,18 +416,18 @@ actionLoop:
 			// skip whitespaces in key
 			continue actionLoop
 		case !quoted && c == ',':
-			f, err := actionsmod.Get(ckey)
+			f, err := actionsmod.Get(ckey.String())
 			if err != nil {
 				return nil, err
 			}
 			res = append(res, ruleAction{
-				Key:   ckey,
-				Value: cval,
+				Key:   ckey.String(),
+				Value: cval.String(),
 				F:     f,
 				Atype: f.Type(),
 			})
-			ckey = ""
-			cval = ""
+	                ckey.Reset()
+	                cval.Reset()
 			iskey = true
 		case iskey && c == ':':
 			iskey = false
@@ -440,18 +443,18 @@ actionLoop:
 				// skip unquoted whitespaces
 				continue actionLoop
 			}
-			cval += string(c)
+			cval.WriteString(string(c))
 		case iskey:
-			ckey += string(c)
+			ckey.WriteString(string(c))
 		}
 		if i+1 == len(actions) {
-			f, err := actionsmod.Get(ckey)
+			f, err := actionsmod.Get(ckey.String())
 			if err != nil {
 				return nil, err
 			}
 			res = append(res, ruleAction{
-				Key:   ckey,
-				Value: cval,
+				Key:   ckey.String(),
+				Value: cval.String(),
 				F:     f,
 				Atype: f.Type(),
 			})


### PR DESCRIPTION
Use string builder in parseActions() function to efficiently concatenate strings and optimize memory usage. Becnhmake profile (testing/coreruleset) shows less allocations, less CPU usage and overall improved performance (~ 2-3%)

Signed-off-by: Manoj Gopalakrishnan <manoj.gopalakrishnan@intel.com>

> Thank you for contributing to Coraza WAF, your effort is greatly appreciated
> Before submitting check if what you want to add to `coraza` list meets [quality standards](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#quality-standards) before sending pull request. Thanks!

**Make sure that you've checked the boxes below before you submit PR:**

- [ ] My code includes positive and negative tests.
- [ ] I have an appropriate description with correct grammar.
- [ ] I have read [Contribution guidelines](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#contribution-guidelines), [maintainers note](https://github.com/corazawaf/coraza/blob/master/CONTRIBUTING.md#maintainers) and [Quality standard](https://github.com/github.com/corazawaf/coraza/v3sso/coraza-waf/blob/master/CONTRIBUTING.md#quality-standards).
- [ ] My code is properly linted and passes pre-commit tests.

Thanks for your contribution :heart: